### PR TITLE
feat: support WORKFLOW_NAME and PROJECT_LINK

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Displays FirmwareCI job results directly in Gerrit's Checks tab with real-time s
 
    ```bash
    export FWCI_TOKEN="your-token"
-   export FWCI_WORKFLOW_ID="your-workflow-id"
+   export FWCI_WORKFLOW_NAME="my-firmware-workflow"
    export BINARIES="Binary=path/to/firmware.bin"
    export COMMIT_HASH="$(git rev-parse HEAD)"
    ```
@@ -38,14 +38,26 @@ Displays FirmwareCI job results directly in Gerrit's Checks tab with real-time s
 
 ### Required
 
-| Variable           | Description                                   |
-| ------------------ | --------------------------------------------- |
-| `FWCI_TOKEN`       | FirmwareCI authentication token               |
-| `FWCI_WORKFLOW_ID` | Workflow ID to execute                        |
-| `BINARIES`         | Key-value pairs of template names to binary paths |
-| `COMMIT_HASH`      | Git commit hash                               |
+| Variable            | Description                                                       |
+| ------------------- | ----------------------------------------------------------------- |
+| `FWCI_TOKEN`        | FirmwareCI authentication token                                   |
+| `FWCI_WORKFLOW_NAME`| Name of the FirmwareCI workflow (preferred over `FWCI_WORKFLOW_ID`) |
+| `FWCI_WORKFLOW_ID`  | *(Deprecated)* Workflow ULID — use `FWCI_WORKFLOW_NAME` instead  |
+| `COMMIT_HASH`       | Git commit hash                                                   |
 
-### Gerrit Integration (Optional)
+Workflow reference: provide either `FWCI_WORKFLOW_NAME` or `FWCI_WORKFLOW_ID` (mutually exclusive; exactly one must be set).
+
+### Optional
+
+| Variable              | Description |
+| --------------------- | ----------- |
+| `BINARIES`            | Semicolon-separated `template=path` pairs. Paths may be local files, HTTP/S URLs, or S3 URIs. Example: `fw=./build/fw.bin;bl=./build/bl.bin` |
+| `FWCI_PROJECT_LINK`   | Repo containing the FirmwareCI workflow config — required when it differs from the repo being tested. Copy from the Workflows page (copy button next to the project name). Accepts with or without scheme; `org/repo` is sufficient for same-org repos. Example: `github.com/my-org/firmware-config` |
+| `FWCI_EMAIL`          | Account email (alternative to `FWCI_TOKEN`) |
+| `FWCI_PASSWORD`       | Account password (alternative to `FWCI_TOKEN`) |
+| `FWCI_API`            | API endpoint. Default: `https://api.firmwareci.9esec.dev:8443` |
+
+### Gerrit Metadata (Optional)
 
 | Variable           | Description                |
 | ------------------ | -------------------------- |
@@ -54,14 +66,6 @@ Displays FirmwareCI job results directly in Gerrit's Checks tab with real-time s
 | `CHANGE_NUMBER`    | Gerrit change number       |
 | `CURRENT_REVISION` | Current revision           |
 | `PATCHSET`         | Patchset number            |
-
-### Alternative Authentication
-
-| Variable        | Description                                              |
-| --------------- | -------------------------------------------------------- |
-| `FWCI_EMAIL`    | Account email (instead of token)                         |
-| `FWCI_PASSWORD` | Account password (instead of token)                      |
-| `FWCI_API`      | API URL (default: <https://api.firmwareci.9esec.dev:8443>) |
 
 ### Plugin Configuration
 
@@ -119,10 +123,10 @@ stage('Deploy to FirmwareCI') {
         }
 
         withCredentials([
-            string(credentialsId: 'firmwareci-token', variable: 'FWCI_TOKEN'),
-            string(credentialsId: 'firmwareci-workflow-id', variable: 'FWCI_WORKFLOW_ID')
+            string(credentialsId: 'firmwareci-token', variable: 'FWCI_TOKEN')
         ]) {
             sh '''
+                export FWCI_WORKFLOW_NAME="my-firmware-workflow"
                 export COMMIT_HASH="${GERRIT_PATCHSET_REVISION}"
                 export BINARIES="Binary=build/firmware.bin"
                 export CHANGE_ID="${GERRIT_CHANGE_ID:-}"
@@ -136,6 +140,19 @@ stage('Deploy to FirmwareCI') {
         }
     }
 }
+```
+
+### Cross-Repository Workflow Config
+
+When the FirmwareCI workflow config lives in a different repository, add `FWCI_PROJECT_LINK`:
+
+```groovy
+sh '''
+    export FWCI_WORKFLOW_NAME="my-firmware-workflow"
+    export FWCI_PROJECT_LINK="github.com/my-org/firmware-config"
+    ...
+    ./job-request-script.sh
+'''
 ```
 
 ## Plugin Installation

--- a/job-request-script.sh
+++ b/job-request-script.sh
@@ -14,10 +14,18 @@ fi
 
 
 # Check required environment variables
-if [ -z "$FWCI_WORKFLOW_ID" ] || [ -z "$COMMIT_HASH" ]; then
-    echo "ERROR: Missing required environment variables:"
-    echo "  FWCI_WORKFLOW_ID: ${FWCI_WORKFLOW_ID:-'(not set)'}"
-    echo "  COMMIT_HASH: ${COMMIT_HASH:-'(not set)'}"
+if [ -z "$FWCI_WORKFLOW_NAME" ] && [ -z "$FWCI_WORKFLOW_ID" ]; then
+    echo "ERROR: Missing workflow reference. Set one of:"
+    echo "  FWCI_WORKFLOW_NAME (preferred): workflow name as shown in FirmwareCI"
+    echo "  FWCI_WORKFLOW_ID (deprecated): workflow ULID"
+    exit 1
+fi
+if [ -n "$FWCI_WORKFLOW_NAME" ] && [ -n "$FWCI_WORKFLOW_ID" ]; then
+    echo "ERROR: FWCI_WORKFLOW_NAME and FWCI_WORKFLOW_ID are mutually exclusive"
+    exit 1
+fi
+if [ -z "$COMMIT_HASH" ]; then
+    echo "ERROR: Missing required environment variable: COMMIT_HASH"
     exit 1
 fi
 
@@ -39,9 +47,39 @@ apt-get update && apt-get install -y curl jq
 
 # Configuration
 FWCI_API="${FWCI_API:-https://api.firmwareci.9esec.dev:8443}"
+
+# Determine workflow reference, JSON key, and VCS query params (for name-based resolution)
+if [ -n "$FWCI_WORKFLOW_NAME" ]; then
+    WORKFLOW_REF="$FWCI_WORKFLOW_NAME"
+    WORKFLOW_JSON_KEY="workflow_name"
+    VCS_PARAMS=""
+    if [ -n "$FWCI_PROJECT_LINK" ]; then
+        # Strip scheme if present, then split into host/org/repo
+        LINK="${FWCI_PROJECT_LINK#*://}"
+        IFS='/' read -ra PARTS <<< "$LINK"
+        HOST="${PARTS[0]}"
+        ORG="${PARTS[1]}"
+        REPO="${PARTS[2]}"
+        if [[ "$HOST" == *"github"* ]]; then
+            PROVIDER="github"
+        elif [[ "$HOST" == *"gitlab"* ]]; then
+            PROVIDER="gitlab"
+        fi
+        if [ -n "$PROVIDER" ] && [ -n "$ORG" ] && [ -n "$REPO" ]; then
+            VCS_PARAMS="?provider=${PROVIDER}&org=${ORG}&repo=${REPO}"
+        fi
+    fi
+else
+    WORKFLOW_REF="$FWCI_WORKFLOW_ID"
+    WORKFLOW_JSON_KEY="workflow_id"
+    VCS_PARAMS=""
+fi
+
 echo "=== FirmwareCI Deployment ======"
 echo "API: ${FWCI_API}"
-echo "Workflow ID: ${FWCI_WORKFLOW_ID}"
+[ -n "$FWCI_WORKFLOW_NAME" ] && echo "Workflow name: ${FWCI_WORKFLOW_NAME}"
+[ -n "$FWCI_WORKFLOW_ID" ]   && echo "Workflow ID: ${FWCI_WORKFLOW_ID} (deprecated)"
+[ -n "$FWCI_PROJECT_LINK" ]  && echo "Project link: ${FWCI_PROJECT_LINK}"
 echo "Commit hash: ${COMMIT_HASH}"
 [ -n "$BINARIES" ] && echo "Templates-Keys -> Files: ${BINARIES}"
 echo "================================"
@@ -54,11 +92,11 @@ if [ "$AUTH_METHOD" = "email_password" ]; then
     LOGIN_RESPONSE=$(curl -s -X POST "${FWCI_API}/login" \
     -H "Content-Type: application/json" \
     -d "{\"email\": \"${FWCI_EMAIL}\", \"password\": \"${FWCI_PASSWORD}\"}")
-    
+
     echo "Login response: ${LOGIN_RESPONSE}"
     STATUS_CODE=$(echo "${LOGIN_RESPONSE}" | jq -r '.code // empty')
     ACCESS_TOKEN=$(echo "${LOGIN_RESPONSE}" | jq -r '.data // empty')
-    
+
     if [ -z "$ACCESS_TOKEN" ] || [ "$STATUS_CODE" != "200" ]; then
         echo "ERROR: Failed to get access token"
         echo "Status code: ${STATUS_CODE}"
@@ -73,9 +111,9 @@ fi
 # Step 2: Upload binaries to server (optional)
 if [ -n "$BINARIES" ]; then
     echo "Step 2: Uploading binaries..."
-    
+
     CURL_FORM_ARGS=()
-    
+
     for key in "${!BINARIES_MAP[@]}"; do
         file="${BINARIES_MAP[$key]}"
         if [ -f "$file" ]; then
@@ -85,7 +123,7 @@ if [ -n "$BINARIES" ]; then
         fi
     done
 
-    UPLOAD_RESPONSE=$(curl -s -X POST "${FWCI_API}/v0/binaries/${FWCI_WORKFLOW_ID}" \
+    UPLOAD_RESPONSE=$(curl -s -X POST "${FWCI_API}/v0/binaries/${WORKFLOW_REF}${VCS_PARAMS}" \
         -H "Authorization: ${ACCESS_TOKEN}" \
         -H "Content-Type: multipart/form-data" \
         "${CURL_FORM_ARGS[@]}")
@@ -93,21 +131,21 @@ if [ -n "$BINARIES" ]; then
     STATUS_CODE=$(echo "${UPLOAD_RESPONSE}" | jq -r '.code // empty')
 
     DATA=$(echo "${UPLOAD_RESPONSE}" | jq -c '.data // empty')
-    
+
     if [ -z "$DATA" ] || [ "$STATUS_CODE" != "201" ]; then
         ERROR_MSG=$(echo "${UPLOAD_RESPONSE}" | jq -r '.error // empty')
         echo "ERROR: Failed to upload binaries"
         [ -n "$ERROR_MSG" ] && echo "Error message: $ERROR_MSG"
         exit 1
     fi
-    
+
     BINARIES_JSON="$DATA"
 
     if [ "${#REMOTE_BINARIES_MAP[@]}" -gt 0 ]; then
         REMOTE_JSON=$(printf '{%s}' "$(IFS=,; for key in "${!REMOTE_BINARIES_MAP[@]}"; do printf '"%s":"%s"' "$key" "${REMOTE_BINARIES_MAP[$key]}"; done)")
         BINARIES_JSON=$(jq -c --argjson local "$BINARIES_JSON" --argjson remote "$REMOTE_JSON" '$local + $remote')
     fi
-    
+
 else
     BINARIES_JSON="{}"
 fi
@@ -127,7 +165,7 @@ JOB_RESPONSE=$(curl -s -X POST "${FWCI_API}/v0/job" \
 -H "Authorization: ${ACCESS_TOKEN}" \
 -H "Content-Type: application/json" \
 -d '{
-    "workflow_id": "'"${FWCI_WORKFLOW_ID}"'",
+    "'"${WORKFLOW_JSON_KEY}"'": "'"${WORKFLOW_REF}"'",
     "binaries": '"${BINARIES_JSON}"',
     "info": {
         "gerrit": {


### PR DESCRIPTION
Adds FWCI_WORKFLOW_NAME as the preferred alternative to the deprecated FWCI_WORKFLOW_ID, and FWCI_PROJECT_LINK for cross-repo workflow config resolution.